### PR TITLE
Extend Distribution trait with probability density function

### DIFF
--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -40,6 +40,14 @@ impl Distribution for Beta {
     type Item = f64;
 
     #[inline]
+    fn pdf(&self, x: f64) -> f64 {
+        let norm = self.b - self.a;
+        let x = (x - self.a) / (self.b - self.a);
+        ((self.alpha - 1.0) * x.ln() + (self.beta - 1.0) * (1.0 - x).ln() -
+            self.ln_beta).exp() / norm
+    }
+
+    #[inline]
     fn cdf(&self, x: f64) -> f64 {
         use special::inc_beta;
         inc_beta((x - self.a) / (self.b - self.a), self.alpha, self.beta, self.ln_beta)
@@ -65,6 +73,27 @@ mod tests {
 
     use {Distribution, Sampler, generator};
     use distributions::Beta;
+
+    #[test]
+    fn pdf() {
+        let beta = Beta::new(2.0, 3.0, -1.0, 2.0);
+
+        let x = vec![
+            -1.00, -0.85, -0.70, -0.55, -0.40, -0.25, -0.10, 0.05, 0.20, 0.35, 0.50,
+             0.65,  0.80,  0.95,  1.10,  1.25,  1.40,  1.55, 1.70, 1.85, 2.00,
+        ];
+        let p = vec![
+            0.000000000000000e+00, 1.805000000000000e-01, 3.240000000000001e-01,
+            4.335000000000000e-01, 5.120000000000000e-01, 5.625000000000001e-01,
+            5.880000000000000e-01, 5.915000000000001e-01, 5.760000000000001e-01,
+            5.445000000000000e-01, 5.000000000000001e-01, 4.455000000000000e-01,
+            3.840000000000001e-01, 3.184999999999999e-01, 2.519999999999999e-01,
+            1.875000000000000e-01, 1.280000000000001e-01, 7.650000000000003e-02,
+            3.600000000000000e-02, 9.499999999999982e-03, 0.000000000000000e+00
+        ];
+
+        assert::within(&x.iter().map(|&x| beta.pdf(x)).collect::<Vec<_>>(), &p, 1e-14);
+    }
 
     #[test]
     fn cdf() {

--- a/src/distributions/gaussian.rs
+++ b/src/distributions/gaussian.rs
@@ -30,6 +30,13 @@ impl Distribution for Gaussian {
     type Item = f64;
 
     #[inline]
+    fn pdf(&self, x: f64) -> f64 {
+        use std::f64::consts::PI;
+        let var = self.sigma.powi(2);
+        (-(x - self.mu).powi(2) / (2.0*var)).exp() / ((2.0*PI).sqrt() * self.sigma)
+    }
+
+    #[inline]
     fn cdf(&self, x: f64) -> f64 {
         use special::erf;
         use std::f64::consts::SQRT_2;
@@ -138,6 +145,26 @@ mod tests {
 
     use Distribution;
     use distributions::Gaussian;
+
+    #[test]
+    fn pdf() {
+        let gaussian = Gaussian::new(1.0, 2.0);
+
+        let x = vec![
+            -4.0, -3.5, -3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0,
+            0.5,  1.0,  1.5,  2.0,  2.5,  3.0,  3.5,  4.0
+        ];
+        let p = vec![
+            8.764150246784270e-03, 1.586982591783371e-02, 2.699548325659403e-02,
+            4.313865941325577e-02, 6.475879783294587e-02, 9.132454269451096e-02,
+            1.209853622595717e-01, 1.505687160774022e-01, 1.760326633821498e-01,
+            1.933340584014246e-01, 1.994711402007164e-01, 1.933340584014246e-01,
+            1.760326633821498e-01, 1.505687160774022e-01, 1.209853622595717e-01,
+            9.132454269451096e-02, 6.475879783294587e-02
+        ];
+
+        assert::within(&x.iter().map(|&x| gaussian.pdf(x)).collect::<Vec<_>>(), &p, 1e-14);
+    }
 
     #[test]
     fn cdf() {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -20,6 +20,14 @@ impl Uniform {
 impl Distribution for Uniform {
     type Item = f64;
 
+    fn pdf(&self, x: f64) -> f64 {
+        if x < self.a || x > self.b {
+            0.0
+        } else {
+            1.0 / (self.b - self.a)
+        }
+    }
+
     fn cdf(&self, x: f64) -> f64 {
         if x <= self.a {
             0.0
@@ -45,6 +53,15 @@ impl Distribution for Uniform {
 mod tests {
     use {Distribution, Sampler};
     use distributions::Uniform;
+
+    #[test]
+    fn pdf() {
+        let uniform = Uniform::new(-1.0, 1.0);
+        let x = vec![-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5];
+        let p = vec![0.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.0];
+
+        assert_eq!(x.iter().map(|&x| uniform.pdf(x)).collect::<Vec<_>>(), p);
+    }
 
     #[test]
     fn cdf() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ pub mod distributions;
 pub trait Distribution {
     type Item;
 
+    /// Compute the probability density function (PDF) as point `x`.
+    fn pdf(&self, x: Self::Item) -> f64;
+
     /// Compute the cumulative distribution function (CDF) at point `x`.
     fn cdf(&self, x: Self::Item) -> f64;
 


### PR DESCRIPTION
I started implementing something similar before I found this repository. I would like to use this crate instead but I need the probability density function for what I'm doing. This adds the `pdf()` function to the `Distribution` trait and implements the `pdf()` function on `Gaussian`, `Beta` and `Uniform`.