### PR TITLE
Support more compliation targets (including WebAssembly, no_std, and miri)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,26 @@ readme = "README.md"
 categories = ["algorithms", "science"]
 keywords = ["distribution", "probability", "sampling", "statistics", "random"]
 
+[features]
+default = ["system_math"]
+
+# Activating feature "system_math" (which is the default) instructs `probability`
+# to use the system math C library for mathematical operations. Deactivate this
+# default feature if no system math C library is available on your compilation
+# target (e.g., if you compile to WebAssembly, or if you want test for undefined
+# behaviour using `miri`).
+system_math = ["special/system_math"]
+
+# Feature "std" is active by default. Deactivate it if you want to compile to a
+# `no_std` target (e.g., a microcontroller). You'll likely want to deactivate
+# feature "system_math" as well in this case.
+std = ["special/std"]
+
 [dependencies]
 random = "0.12"
-special = "0.8"
+# FIXME: use upstream version of `special` if proposed changes get accepted.
+# special = {path = "../special", default-features = false}
+special = {git = "https://github.com/robamler/special.git", rev = "16708ea249ec56fbebfcc91b413142f01671ebd9", default-features = false}
 
 [dev-dependencies]
 assert = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["algorithms", "science"]
 keywords = ["distribution", "probability", "sampling", "statistics", "random"]
 
 [features]
-default = ["system_math"]
+default = ["std", "system_math"]
 
 # Activating feature "system_math" (which is the default) instructs `probability`
 # to use the system math C library for mathematical operations. Deactivate this

--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -1,5 +1,9 @@
+use alloc::{vec, vec::Vec};
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A Bernoulli distribution.
 #[derive(Clone, Copy, Debug)]
@@ -112,7 +116,7 @@ impl distribution::Mean for Bernoulli {
 
 impl distribution::Median for Bernoulli {
     fn median(&self) -> f64 {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
         match self.p.partial_cmp(&self.q) {
             Some(Less) => 0.0,
             Some(Equal) => 0.5,
@@ -124,7 +128,7 @@ impl distribution::Median for Bernoulli {
 
 impl distribution::Modes for Bernoulli {
     fn modes(&self) -> Vec<u8> {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
         match self.p.partial_cmp(&self.q) {
             Some(Less) => vec![0],
             Some(Equal) => vec![0, 1],
@@ -164,6 +168,7 @@ impl distribution::Variance for Bernoulli {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -193,6 +193,7 @@ mod tests {
     );
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn density() {
         let d = new!(2.0, 3.0, -1.0, 2.0);
         let x = vec![
@@ -287,6 +288,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inverse() {
         let d = new!(1.0, 2.0, 3.0, 4.0);
         let p = vec![
@@ -373,6 +375,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn sample() {
         for x in Independent(&new!(1.0, 2.0, 7.0, 42.0), &mut source::default()).take(100) {
             assert!(7.0 <= x && x <= 42.0);

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A beta distribution.
 #[derive(Clone, Copy, Debug)]
@@ -185,6 +190,7 @@ impl distribution::Variance for Beta {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 
@@ -273,7 +279,7 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::E;
+        use core::f64::consts::E;
         let d = vec![
             new!(1.0, 1.0, 0.0, 1.0),
             new!(1.0, 1.0, 0.0, E),

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A binomial distribution.
 #[derive(Clone, Copy, Debug)]
@@ -82,7 +87,7 @@ impl distribution::Discrete for Binomial {
     /// 1. C. Loader, “Fast and Accurate Computation of Binomial Probabilities,”
     ///    2000.
     fn mass(&self, x: usize) -> f64 {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
 
         if self.p == 0.0 {
             return if x == 0 { 1.0 } else { 0.0 };
@@ -134,8 +139,8 @@ impl distribution::Distribution for Binomial {
 
 impl distribution::Entropy for Binomial {
     fn entropy(&self) -> f64 {
+        use core::f64::consts::PI;
         use distribution::Discrete;
-        use std::f64::consts::PI;
 
         if self.n > 10000 && self.npq > 80.0 {
             // Use a normal approximation.
@@ -239,8 +244,8 @@ impl distribution::Mean for Binomial {
 
 impl distribution::Median for Binomial {
     fn median(&self) -> f64 {
+        use core::f64::consts::LN_2;
         use distribution::Inverse;
-        use std::f64::consts::LN_2;
 
         if self.np.fract() == 0.0 || (self.p == 0.5 && self.n % 2 != 0) {
             self.np
@@ -410,6 +415,7 @@ fn ln_d0(x: f64, np: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A categorical distribution.
 #[derive(Clone, Debug)]
@@ -180,6 +185,7 @@ impl distribution::Variance for Categorical {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use prelude::*;
 
     macro_rules! new(
@@ -218,7 +224,7 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::LN_2;
+        use core::f64::consts::LN_2;
         assert_eq!(new!(equal 2).entropy(), LN_2);
         assert_eq!(new!([0.1, 0.2, 0.3, 0.4]).entropy(), 1.2798542258336676);
     }

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
 
@@ -44,7 +46,7 @@ impl Cauchy {
 impl distribution::Continuous for Cauchy {
     #[inline]
     fn density(&self, x: f64) -> f64 {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         let deviation = x - self.x_0;
         self.gamma / (PI * (self.gamma * self.gamma + deviation * deviation))
     }
@@ -55,7 +57,7 @@ impl distribution::Distribution for Cauchy {
 
     #[inline]
     fn distribution(&self, x: f64) -> f64 {
-        use std::f64::consts::FRAC_1_PI;
+        use core::f64::consts::FRAC_1_PI;
         FRAC_1_PI * ((x - self.x_0) / self.gamma).atan() + 0.5
     }
 }
@@ -63,14 +65,14 @@ impl distribution::Distribution for Cauchy {
 impl distribution::Entropy for Cauchy {
     #[inline]
     fn entropy(&self) -> f64 {
-        (std::f64::consts::PI * 4.0 * self.gamma).ln()
+        (core::f64::consts::PI * 4.0 * self.gamma).ln()
     }
 }
 
 impl distribution::Inverse for Cauchy {
     #[inline]
     fn inverse(&self, p: f64) -> f64 {
-        use std::f64::{consts::PI, INFINITY, NEG_INFINITY};
+        use core::f64::{consts::PI, INFINITY, NEG_INFINITY};
 
         should!((0.0..=1.0).contains(&p));
 
@@ -114,6 +116,7 @@ impl distribution::Sample for Cauchy {
 #[cfg(test)]
 mod tests {
     use assert;
+    use alloc::{vec, vec::Vec};
     use prelude::*;
 
     macro_rules! new(
@@ -176,14 +179,14 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         assert_eq!(new!(2.0, 1.0).entropy(), (PI * 4.0).ln());
         assert::close(new!(3.0, 5.2).entropy(), 4.1796828725566719243, 1e-15);
     }
 
     #[test]
     fn inverse() {
-        use std::f64::{INFINITY, NEG_INFINITY};
+        use core::f64::{INFINITY, NEG_INFINITY};
 
         let d = new!(2.0, 3.0);
         let x = vec![

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -156,6 +156,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn distribution() {
         let d = new!(2.0);
         let x = vec![
@@ -191,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inverse() {
         use std::f64::INFINITY;
 

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// An exponential distribution.
 #[derive(Clone, Copy, Debug)]
@@ -80,7 +85,7 @@ impl distribution::Mean for Exponential {
 impl distribution::Median for Exponential {
     #[inline]
     fn median(&self) -> f64 {
-        use std::f64::consts::LN_2;
+        use core::f64::consts::LN_2;
         self.lambda.recip() * LN_2
     }
 }
@@ -123,6 +128,7 @@ impl distribution::Variance for Exponential {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 
@@ -187,14 +193,14 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::E;
+        use core::f64::consts::E;
         assert_eq!(new!(E).entropy(), 0.0);
     }
 
     #[test]
     #[cfg_attr(miri, ignore)]
     fn inverse() {
-        use std::f64::INFINITY;
+        use core::f64::INFINITY;
 
         let d = new!(2.0);
         let x = vec![
@@ -235,7 +241,7 @@ mod tests {
 
     #[test]
     fn median() {
-        use std::f64::consts::LN_2;
+        use core::f64::consts::LN_2;
         assert_eq!(new!(LN_2).median(), 1.0);
     }
 

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A gamma distribution.
 #[derive(Clone, Copy, Debug)]
@@ -164,6 +169,7 @@ pub fn sample<S: Source>(k: f64, source: &mut S) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 

--- a/src/distribution/gaussian.rs
+++ b/src/distribution/gaussian.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A Gaussian distribution.
 #[derive(Clone, Copy, Debug)]
@@ -16,7 +21,7 @@ impl Gaussian {
     /// It should hold that `sigma > 0`.
     #[inline]
     pub fn new(mu: f64, sigma: f64) -> Self {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         should!(sigma > 0.0);
         Gaussian {
             mu,
@@ -55,8 +60,8 @@ impl distribution::Distribution for Gaussian {
     type Value = f64;
 
     fn distribution(&self, x: f64) -> f64 {
+        use core::f64::consts::SQRT_2;
         use special::Error;
-        use std::f64::consts::SQRT_2;
         (1.0 + ((x - self.mu) / (self.sigma * SQRT_2)).error()) / 2.0
     }
 }
@@ -64,7 +69,7 @@ impl distribution::Distribution for Gaussian {
 impl distribution::Entropy for Gaussian {
     #[inline]
     fn entropy(&self) -> f64 {
-        use std::f64::consts::{E, PI};
+        use core::f64::consts::{E, PI};
         0.5 * (2.0 * PI * E * self.sigma * self.sigma).ln()
     }
 }
@@ -155,7 +160,7 @@ impl distribution::Variance for Gaussian {
 /// Gaussian distribution.
 #[allow(clippy::excessive_precision)]
 pub fn inverse(p: f64) -> f64 {
-    use std::f64::{INFINITY, NEG_INFINITY};
+    use core::f64::{INFINITY, NEG_INFINITY};
 
     should!((0.0..=1.0).contains(&p));
 
@@ -406,6 +411,7 @@ const W: [f64; 128] = [
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 
@@ -483,13 +489,13 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         assert_eq!(new!(0.0, 1.0).entropy(), ((2.0 * PI).ln() + 1.0) / 2.0);
     }
 
     #[test]
     fn inverse() {
-        use std::f64::{INFINITY, NEG_INFINITY};
+        use core::f64::{INFINITY, NEG_INFINITY};
 
         let d = new!(-1.0, 0.25);
         let p = vec![

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -1,6 +1,11 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use distribution::Inverse;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A Laplace distribution.
 #[derive(Clone, Copy, Debug)]
@@ -55,7 +60,7 @@ impl distribution::Distribution for Laplace {
 impl distribution::Entropy for Laplace {
     #[inline]
     fn entropy(&self) -> f64 {
-        (std::f64::consts::E * 2.0 * self.b).ln()
+        (core::f64::consts::E * 2.0 * self.b).ln()
     }
 }
 
@@ -65,12 +70,12 @@ impl distribution::Inverse for Laplace {
         should!((0.0..=1.0).contains(&p));
         if p > 0.5 {
             if p == 1.0 {
-                return std::f64::INFINITY;
+                return core::f64::INFINITY;
             }
             self.mu - self.b * (2.0 - 2.0 * p).ln()
         } else {
             if p == 0.0 {
-                return std::f64::NEG_INFINITY;
+                return core::f64::NEG_INFINITY;
             }
             self.mu + self.b * (2.0 * p).ln()
         }
@@ -136,6 +141,7 @@ impl distribution::Variance for Laplace {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 
@@ -199,7 +205,7 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::E;
+        use core::f64::consts::E;
         assert_eq!(new!(2.0, 1.0).entropy(), (2.0 * 1.0 * E).ln());
     }
 
@@ -207,13 +213,13 @@ mod tests {
     fn inverse() {
         let d = new!(2.0, 3.0);
         let x = vec![
-            std::f64::NEG_INFINITY,
+            core::f64::NEG_INFINITY,
             -2.8283137373023006,
             -0.07944154167983575,
             2.0,
             4.079441541679836,
             6.8283137373023015,
-            std::f64::INFINITY,
+            core::f64::INFINITY,
         ];
         let p = vec![0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.00];
 

--- a/src/distribution/logistic.rs
+++ b/src/distribution/logistic.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A logistic distribution.
 #[derive(Clone, Copy, Debug)]
@@ -119,16 +124,17 @@ impl distribution::Skewness for Logistic {
 impl distribution::Variance for Logistic {
     #[inline]
     fn variance(&self) -> f64 {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         (PI * self.s).powi(2) / 3.0
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
+    use core::f64::{INFINITY, NEG_INFINITY};
     use prelude::*;
-    use std::f64::{INFINITY, NEG_INFINITY};
 
     macro_rules! new(
         ($mu:expr, $s:expr) => (Logistic::new($mu, $s));
@@ -241,13 +247,13 @@ mod tests {
 
     #[test]
     fn variance() {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         assert_eq!(new!(1.0, 3.0 / PI).variance(), 3.0);
     }
 
     #[test]
     fn deviation() {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         assert_eq!(new!(1.0, 3.0 / PI).deviation(), 3f64.sqrt());
     }
 }

--- a/src/distribution/lognormal.rs
+++ b/src/distribution/lognormal.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution::{self, Gaussian};
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A lognormal distribution.
 #[derive(Clone, Copy, Debug)]
@@ -45,7 +50,7 @@ impl Default for Lognormal {
 
 impl distribution::Continuous for Lognormal {
     fn density(&self, x: f64) -> f64 {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         if x <= 0.0 {
             0.0
         } else {
@@ -70,7 +75,7 @@ impl distribution::Distribution for Lognormal {
 impl distribution::Entropy for Lognormal {
     #[inline]
     fn entropy(&self) -> f64 {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         (self.sigma * (self.mu + 0.5).exp() * (2.0 * PI).sqrt()).ln()
     }
 }
@@ -138,6 +143,7 @@ impl distribution::Variance for Lognormal {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 
@@ -197,13 +203,13 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         assert_eq!(new!(-0.5, 1.0 / (2.0 * PI).sqrt()).entropy(), 0.0);
     }
 
     #[test]
     fn inverse() {
-        use std::f64::INFINITY;
+        use core::f64::INFINITY;
         let d = new!(1.0, 2.0);
         let p = vec![
             0.00, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65,

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -1,6 +1,11 @@
 //! Probability distributions.
 
+use alloc::vec::Vec;
+
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A continuous distribution.
 pub trait Continuous: Distribution {

--- a/src/distribution/pert.rs
+++ b/src/distribution/pert.rs
@@ -179,6 +179,7 @@ mod tests {
     );
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn density() {
         let d = new!(-1.0, 0.5, 2.0);
         let beta = Beta::new(3.0, 3.0, -1.0, 2.0);
@@ -255,6 +256,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inverse() {
         let d = new!(-1.0, 0.5, 2.0);
         let p = vec![0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
@@ -294,6 +296,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn median() {
         assert::close(new!(0.0, 0.5, 1.0).median(), 0.5, 1e-14);
         assert::close(new!(0.0, 0.3, 1.0).median(), 0.3509994849491181, 1e-14);
@@ -305,6 +308,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn sample() {
         for x in Independent(&new!(7.0, 20.0, 42.0), &mut source::default()).take(100) {
             assert!(7.0 <= x && x <= 42.0);

--- a/src/distribution/pert.rs
+++ b/src/distribution/pert.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A PERT distribution.
 #[derive(Clone, Copy, Debug)]
@@ -171,6 +176,7 @@ impl distribution::Variance for Pert {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 
@@ -239,7 +245,7 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::E;
+        use core::f64::consts::E;
         let d = vec![
             new!(0.0, 0.5, 1.0),
             new!(0.0, 0.5, E),

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -1,5 +1,10 @@
+use alloc::{vec, vec::Vec};
+
 use distribution;
 use source::Source;
+
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
 
 /// A triangular distribution.
 #[derive(Clone, Copy, Debug)]
@@ -167,6 +172,7 @@ impl distribution::Variance for Triangular {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use assert;
     use prelude::*;
 

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -1,6 +1,9 @@
 use distribution;
 use source::Source;
 
+#[cfg(not(feature = "std"))]
+use special::FloatExt;
+
 /// A continuous uniform distribution.
 #[derive(Clone, Copy, Debug)]
 pub struct Uniform {
@@ -127,6 +130,7 @@ impl distribution::Variance for Uniform {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use prelude::*;
 
     macro_rules! new(
@@ -156,7 +160,7 @@ mod tests {
 
     #[test]
     fn entropy() {
-        use std::f64::consts::E;
+        use core::f64::consts::E;
         assert_eq!(new!(0.0, E).entropy(), 1.0);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,20 @@
 //! let samples = sampler.take(10).collect::<Vec<_>>();
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+extern crate core;
+
 #[cfg(test)]
 extern crate assert;
 
+extern crate alloc;
 extern crate random;
 extern crate special;
 
 macro_rules! nonnan(
-    ($argument:ident) => (if $argument.is_nan() { return ::std::f64::NAN; });
+    ($argument:ident) => (if $argument.is_nan() { return ::core::f64::NAN; });
 );
 
 macro_rules! should(


### PR DESCRIPTION
This is a companion PR to stainless-steel/special#11. The PR is split into two commits that define cargo features `system_math` and `std`, respectively, which are both active by default for backward compatibility. Both feature settings are passed on to the `special` crate. The second commit, which implements the `std` feature, also contains some modifications to support compilation to a `no_std` target (these are mostly "mechanical" changes like replacing `std::f64::consts` with `core::f64::consts`).

I wrote more explanations at stainless-steel/special#11.