### PR TITLE
Adds sample default values for Binomial & Categorical random variables

### DIFF
--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -16,6 +16,13 @@ pub struct Binomial {
     npq: f64,
 }
 
+impl Default for Binomial {
+    #[inline]
+    fn default() -> Self {
+        Self::new(10, 0.5)
+    }
+}
+
 impl Binomial {
     /// Create a binomial distribution with `n` trails and success probability
     /// `p`.

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -13,11 +13,22 @@ pub struct Categorical {
     cumsum: Vec<f64>,
 }
 
+impl Default for Categorical {
+    #[inline]
+    fn default() -> Self {
+        Self::new_from_owned(vec![0.2, 0.2, 0.2, 0.2, 0.2])
+    }
+}
+
 impl Categorical {
     /// Create a categorical distribution with success probability `p`.
     ///
     /// It should hold that `p[i] >= 0`, `p[i] <= 1`, and `sum(p) == 1`.
     pub fn new(p: &[f64]) -> Self {
+        Self::new_from_owned(p.to_vec())
+    }
+
+    pub fn new_from_owned(p: Vec<f64>) -> Self {
         should!(is_probability_vector(p), {
             const EPSILON: f64 = 1e-12;
             p.iter().all(|&p| (0.0..=1.0).contains(&p))
@@ -32,7 +43,7 @@ impl Categorical {
         cumsum[k - 1] = 1.0;
         Categorical {
             k,
-            p: p.to_vec(),
+            p,
             cumsum,
         }
     }


### PR DESCRIPTION
## What 

This PR adds some default implementations for categorical and binomial distributions. Further, it also adds an owned initializer to the categorical random variable so that it is slightly more ergonomic to write code like the following: 

```rust
let categorical = distribution::Categorical::new(vec![....]);
```